### PR TITLE
allow version (token type) dependent SEND

### DIFF
--- a/src/components/Send/SendToken.js
+++ b/src/components/Send/SendToken.js
@@ -436,6 +436,9 @@ const SendToken = ({ tokenId, passLoadingStatus }) => {
                                 <Descriptions.Item label="Document Hash">
                                     {token.info.hash}
                                 </Descriptions.Item>
+                                <Descriptions.Item label="Version">
+                                    {token.info.version}
+                                </Descriptions.Item>
                                 {tokenStats && (
                                     <>
                                         <Descriptions.Item label="Genesis Date">

--- a/src/hooks/useBCH.js
+++ b/src/hooks/useBCH.js
@@ -552,14 +552,14 @@ export default function useBCH() {
         return mintOpReturn
     };
 
-    const buildSendOpReturn = (tokenId, sendQuantityArray) => {
+    const buildSendOpReturn = (tokenId, sendQuantityArray, version = 1) => {
         const sendOpReturn = new Script()
                 .pushSym('return')
                 .pushData(Buffer.concat([
                     Buffer.from('SLP', 'ascii'),
                     Buffer.alloc(1)
                 ]))
-                .pushPush(Buffer.alloc(1, 1))
+                .pushPush(Buffer.alloc(1, version))
                 .pushData(Buffer.from('SEND', 'ascii'))
                 .pushData(Buffer.from(tokenId, 'hex'))
                 for (let i = 0; i < sendQuantityArray.length; i++) {
@@ -705,7 +705,7 @@ export default function useBCH() {
         const tokenInfo = slpBalancesAndUtxos.tokens.find(token => 
             token.tokenId == tokenId
         ).info;
-
+        console.log("tokenInfo", tokenInfo);
         // BEGIN transaction construction.
 
         const tx = new MTX();
@@ -755,7 +755,8 @@ export default function useBCH() {
 
         const sendOpReturn = buildSendOpReturn(
             tokenId,
-            tokenAmountArray
+            tokenAmountArray,
+            tokenInfo.version,
         );
 
         // Add OP_RETURN as first output.


### PR DESCRIPTION
SLP SEND script building can now be called with a variable version property. Current changes only allow for versions != 1 if an already existing token is selected and indexed by the node with the relevant version in TokenRecord. For advanced SEND transactions, version property still defaults to 1.