### PR TITLE
add MintHistory

### DIFF
--- a/src/components/Wallet/MintHistory.js
+++ b/src/components/Wallet/MintHistory.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import Tx from './Tx';
+
+export const TxLink = styled.a``;
+
+const MintHistory = ({ txs, fiatPrice, fiatCurrency }) => {
+    return (
+        <div>
+            {txs.map(tx => (
+                <TxLink
+                    key={tx.txid}
+                    href={`https://explorer.e.cash/tx/${tx.txid}`}
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    <Tx
+                        data={tx}
+                        fiatPrice={fiatPrice}
+                        fiatCurrency={fiatCurrency}
+                        isExternalMint={true}
+                    />
+                </TxLink>
+            ))}
+        </div>
+    );
+};
+
+MintHistory.propTypes = {
+    txs: PropTypes.array,
+    fiatPrice: PropTypes.number,
+    fiatCurrency: PropTypes.string,
+};
+
+export default MintHistory;

--- a/src/components/Wallet/Tx.js
+++ b/src/components/Wallet/Tx.js
@@ -47,6 +47,10 @@ const SentLabel = styled.span`
     font-weight: bold;
     color: ${props => props.theme.secondary} !important;
 `;
+const MintedLabel = styled.span`
+    font-weight: bold;
+    color: ${props => props.theme.secondary} !important;
+`;
 const ReceivedLabel = styled.span`
     font-weight: bold;
     color: ${props => props.theme.primary} !important;
@@ -173,7 +177,7 @@ const TxWrapper = styled.div`
     }
 `;
 
-const Tx = ({ data, fiatPrice, fiatCurrency }) => {
+const Tx = ({ data, fiatPrice, fiatCurrency, isExternalMint = false }) => {
     const txDate =
         typeof data.blocktime === 'undefined'
         || data.blocktime === 0
@@ -233,14 +237,36 @@ const Tx = ({ data, fiatPrice, fiatCurrency }) => {
                                 data.tokenInfo.transactionType === 'GENESIS' ? (
                                     <ReceivedLabel>Genesis</ReceivedLabel>
                                 ) : (
-                                    <SentLabel>Sent</SentLabel>
+                                    <>
+                                        {isExternalMint ? (
+                                            <MintedLabel>Minted</MintedLabel>
+                                        ) : (
+                                            <SentLabel>Sent</SentLabel>
+                                        )}
+                                    </>
                                 )}
                             </>
                         ) : (
                             <ReceivedLabel>Received</ReceivedLabel>
                         )}
                         <br />
-                        {txDate}
+                        {isExternalMint ? (
+                            <>
+                                {data.block == -1 ? (
+                                    <>
+                                        unconfirmed
+                                    </>
+                                ) : (
+                                    <>
+                                        Block {data.block}
+                                    </>
+                                )}
+                            </>
+                        ) : (
+                            <>
+                                {txDate}
+                            </>
+                        )}
                     </DateType>
                     {data.tokenTx ? (
                         <TokenInfo outgoing={data.outgoingTx}>
@@ -445,6 +471,7 @@ Tx.propTypes = {
     data: PropTypes.object,
     fiatPrice: PropTypes.number,
     fiatCurrency: PropTypes.string,
+    isExternalMint: PropTypes.bool,
 };
 
 export default Tx;

--- a/src/utils/mintHistory.js
+++ b/src/utils/mintHistory.js
@@ -1,0 +1,44 @@
+import localforage from "localforage";
+
+
+export const writeMempoolMint = async (mempoolMint) => {
+    try {
+        const key = `externalMints-${mempoolMint.minter_pubkey}`;
+        const mempoolMints = await localforage.getItem(key) || [];
+        mempoolMints.push(mempoolMint);
+
+        await localforage.setItem(key, mempoolMints);
+        console.log("added item to storage", key, mempoolMints);
+    } catch (err) {
+        console.log(`Error in writeMempoolMint()`);
+        console.log(err);
+    }
+}
+
+export const getMempoolMints = async (minterPublicKey) => {
+    try {
+        const key = `externalMints-${minterPublicKey}`;
+        const mempoolMints = await localforage.getItem(key);
+
+        return mempoolMints || [];
+    } catch(err) {
+        console.log(`Error in getMempoolMints()`);
+        console.log(err);
+    }
+}
+
+export const updateMempoolMints = async (minterPublicKey, unconfirmedMints) => {
+    try {
+        const key = `externalMints-${minterPublicKey}`;
+        if (unconfirmedMints.length === 0) {
+            await localforage.removeItem(key);
+            console.log("removed item with key", key);
+        } else {
+            await localforage.setItem(key, unconfirmedMints);
+            console.log("updated item with key", key, unconfirmedMints);
+        }
+    } catch(err) {
+        console.log(`Error in updateMempoolMints()`);
+        console.log(err);
+    }
+}


### PR DESCRIPTION
Due to the usage of SLPv2, MINTs might not contain the authorizer of the transaction in inputs nor outputs and therefore these transactions would not show up in the regular TxHistory. A MintHistory has been added to the Token tab to get around that. MintHistory transactions are collected from seperately indexed Self-Mints for confirmed blocks (via API) and from storage for unconfirmed blocks (via localForage). After every SLPv2 MINT through Checkout, the respective transaction is stored in API format and only deleted if loading the MintHistory from API reveals that transaction as confirmed. Displaying the MintHistory uses a slight modification of TxHistory and thereby allows to embed regular Tx elements.
